### PR TITLE
Add npm workspace for client and use `npm ci` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
           node-version: 20
           cache: npm
       - name: Install
-        run: npm install
+        run: npm ci
       - name: Verify
         run: npm run verify

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "startup-network",
   "version": "1.0.0",
   "main": "server/server.js",
+  "private": true,
+  "workspaces": [
+    "client"
+  ],
   "scripts": {
     "client": "npm --prefix client start",
     "server": "nodemon server/server.js",
@@ -9,7 +13,7 @@
     "build": "npm --prefix client run build",
     "test": "node tools/run_tests.mjs",
     "test:server": "node --test server/tests/**/*.test.js",
-    "test:client": "npm --prefix client test -- --watchAll=false",
+    "test:client": "npm --workspace client test -- --watchAll=false",
     "lint": "node tools/lint.mjs",
     "typecheck": "node tools/typecheck.mjs",
     "verify": "node tools/verify.mjs",


### PR DESCRIPTION
### Motivation
- Fix CI flakiness where client dependencies (e.g., `react-scripts`) were not installed before running client tests.
- Consolidate dependency installation at the repo root so a single install covers the `client` package using npm workspaces.
- Ensure client tests run from the root with `npm --workspace client` so they use the workspace-installed deps.
- Use `npm ci` in CI to produce deterministic installs.

### Description
- Added `private: true` and `workspaces: ["client"]` to `package.json` to enable npm workspaces for the `client` package.
- Updated the `test:client` script in `package.json` to use `npm --workspace client test -- --watchAll=false` instead of `npm --prefix client`.
- Updated `.github/workflows/ci.yml` to run `npm ci` (deterministic install) before running `npm run verify`.
- Kept existing verify/test orchestration intact so the root `verify` script continues to drive CI checks.

### Testing
- No automated tests were executed as part of this change.
- The CI workflow will run `npm run verify` (unchanged) after the updated `npm ci` install step when the workflow runs.